### PR TITLE
CommonExtensions: fix NRE in JID equality

### DIFF
--- a/Cyclops.Core/Helpers/CommonExtensions.cs
+++ b/Cyclops.Core/Helpers/CommonExtensions.cs
@@ -62,8 +62,8 @@ namespace Cyclops
 
         public static bool BaresEqual(this IEntityIdentifier x, IEntityIdentifier y)
         {
-            return x.User.Equals(y.User, StringComparison.InvariantCultureIgnoreCase) &&
-                   x.Server.Equals(y.Server, StringComparison.InvariantCultureIgnoreCase);
+            return string.Equals(x.User, y.User, StringComparison.InvariantCultureIgnoreCase) &&
+                   string.Equals(x.Server, y.Server, StringComparison.InvariantCultureIgnoreCase);
         }
 
         public static bool StringToBool(this string str)


### PR DESCRIPTION
Records like "dotnet/revenrof" somehow ended up in my bookmarks, and they were causing issues when we were trying to compare them with any other JIDs.