### PR TITLE
ConferencesList: enable virtualization for the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Fixed
-- [#50: Crash when opening a hyperlink](https://github.com/ForNeVeR/CyclopsChat/issues/50)
-- Cyrillic hyperlinks aren't highlighted
+- [#50: Crash when opening a hyperlink](https://github.com/ForNeVeR/CyclopsChat/issues/50).
+- Cyrillic hyperlinks aren't highlighted.
+- Low performance when adding a lot of conferences into the conference browser.
 
 ## [2.0.1] - 2022-05-07
 ### Fixed

--- a/Cyclops.MainApplication/View/ConferencesList.xaml
+++ b/Cyclops.MainApplication/View/ConferencesList.xaml
@@ -70,8 +70,13 @@
             <Button IsDefault="True" Command="{Binding OpenConference}" Grid.Row="3" Content="{Binding Path=ConferenceList.Join, Source={StaticResource ResourceWrapper}}" Width="90" HorizontalAlignment="Right" VerticalAlignment="Center" Height="22" Margin="0,0,3,0" />
 
             <!-- room list -->
-			<ListBox x:Name="listBox" Grid.Row="2" ItemsSource="{Binding Conferences}" ScrollViewer.HorizontalScrollBarVisibility="Hidden" ScrollViewer.CanContentScroll="False" SelectedItem="{Binding SelectedConference, Mode=TwoWay}" ItemTemplate="{DynamicResource ConferenceDataTemplate}">
-				<i:Interaction.Triggers>
+			<ListBox x:Name="listBox" Grid.Row="2"
+                     ItemTemplate="{DynamicResource ConferenceDataTemplate}"
+                     ItemsSource="{Binding Conferences}"
+                     SelectedItem="{Binding SelectedConference, Mode=TwoWay}"
+                     ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+                     VirtualizingStackPanel.ScrollUnit="Pixel">
+                <i:Interaction.Triggers>
 					<i:EventTrigger EventName="MouseDoubleClick" SourceObject="{Binding ElementName=listBox}">
 						<galasoft:EventToCommand Command="{Binding OpenConference}" />
 					</i:EventTrigger>


### PR DESCRIPTION
Turns out that it gets disabled by `ScrollViewer.CanContentScroll="False"`. I had to apply an alternative workaround for the same problem. See this for details: https://stackoverflow.com/a/58272065/2684760