### PR TITLE
.gitignore: clean up the Jabber-Net stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 ﻿/.idea/
-/Jabber-net/2005-jabber-net.xml
 
 bin/
-bin5/
 obj/
-obj5/
 
 *.user


### PR DESCRIPTION
We no longer use Jabber-Net and thus doesn't need this in our `.gitignore`.